### PR TITLE
headers should return as HASHREF

### DIFF
--- a/lib/JIRA/REST/OAuth.pm
+++ b/lib/JIRA/REST/OAuth.pm
@@ -135,7 +135,7 @@ sub _generate_oauth_request
 
     my @rv = ($path, $query);
     if ($method =~ /^(?:POST|PUT)$/) {
-        @rv = ($path, $query, $content, $headers);
+        @rv = ($path, $query, $content, { $headers->flatten() });
     }
 
     return @rv;


### PR DESCRIPTION
_generate_oauth_request returns $headers as a blessed object ref on PUT/POST - REST::Client wants this as a HASHREF, however.